### PR TITLE
RHMAP-15121 - add travis file and move devDependencies to dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+group: edge
+sudo: required
+services:
+  - mongodb
+  - docker
+node_js:
+  - "0.10"
+  - "4.4.3"
+before_install:
+  - npm install fh-build -g
+  - fh-build template
+install: npm install

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "mobilespec-mobile-spec-portal",
   "version": "0.0.0",
-  "dependencies": {},
-  "license": "Apache-2.0",
-  "devDependencies": {
+  "dependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",
@@ -27,6 +25,8 @@
     "time-grunt": "~0.3.1",
     "jshint-stylish": "~0.1.5"
   },
+  "license": "Apache-2.0",
+  "devDependencies": {},
   "engines": {
     "node": ">=0.10.0"
   }


### PR DESCRIPTION
## Motivation
Missing travis build

## Result
Add travis file, move devDependencies to dependencies as fh-build runs npm install with the production flag set and add travis CI service to this repo

## Jira
https://issues.jboss.org/browse/RHMAP-15121